### PR TITLE
feat: implement automatic Pilot role assignment and comprehensive tests

### DIFF
--- a/backend/prisma/migrations/20250802100224_remove_user_role_table/migration.sql
+++ b/backend/prisma/migrations/20250802100224_remove_user_role_table/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `UserRole` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "UserRole" DROP CONSTRAINT "UserRole_roleId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "UserRole" DROP CONSTRAINT "UserRole_userId_fkey";
+
+-- DropTable
+DROP TABLE "UserRole";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -115,7 +115,6 @@ model Role {
   id             Int              @id @default(autoincrement())
   name           String           @unique
   users          User[]           @relation("UserRoles")
-  UserRole       UserRole[]
   RolePermission RolePermission[]
 }
 
@@ -130,22 +129,13 @@ model User {
 
   base         Base         @relation(fields: [baseId], references: [id])
   roles        Role[]       @relation("UserRoles")
-  UserRole     UserRole[]
   flights      Flight[]
   flightDuties FlightDuty[]
   createdAt    DateTime     @default(now())
   updateAt     DateTime     @default(now()) @updatedAt
 }
 
-model UserRole {
-  userId Int
-  roleId Int
 
-  user User @relation(fields: [userId], references: [id])
-  role Role @relation(fields: [roleId], references: [id])
-
-  @@id([userId, roleId])
-}
 
 model Permission {
   id              Int              @id @default(autoincrement())

--- a/backend/prisma/seed/eventsListSeed.ts
+++ b/backend/prisma/seed/eventsListSeed.ts
@@ -174,7 +174,7 @@ export const eventList: CheckListOutput = {
           "02": {
             "id": "placeholder-prisma-id",
             "logicalId": "[COCKPIT_PREPARATION][OVERHEAD_PANEL][ENG_1__ENG_2_FIRE][SAFETY_COMPROMISE][02]",
-            "name": "ENG 1 FIRE pb-sw not IN or not GUARDED",
+            "name": "ENG 2 FIRE pb-sw not IN or not GUARDED",
             "reference": "",
             "description": "",
             "severityId": 4

--- a/backend/src/flights/controllers/routes.controller.ts
+++ b/backend/src/flights/controllers/routes.controller.ts
@@ -1,9 +1,9 @@
 import { Controller, Get, Post, Query } from '@nestjs/common';
 import { CGNAService } from '../service/cgna.service';
 import { FlightDutyService } from '../service/flightDuty.service';
-import { PrismaService } from 'src/database/prisma/prisma.service';
 import { Prisma } from '@prisma/client';
 import { RoutesService } from '../service/routes.service';
+import { PrismaService } from '../../database/prisma/prisma.service';
 
 @Controller('routes')
 export class RoutesController {

--- a/backend/src/flights/route.module.ts
+++ b/backend/src/flights/route.module.ts
@@ -3,7 +3,7 @@ import { Module } from '@nestjs/common';
 import { RoutesController } from './controllers/routes.controller';
 import { CGNAService } from './service/cgna.service';
 import { FlightDutyService } from './service/flightDuty.service';
-import { PrismaModule } from 'src/database/prisma/prisma.module';
+import { PrismaModule } from '../database/prisma/prisma.module';
 import { RoutesService } from './service/routes.service';
 
 @Module({

--- a/backend/src/flights/service/routes.service.ts
+++ b/backend/src/flights/service/routes.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { CGNAService } from './cgna.service';
-import { PrismaService } from 'src/database/prisma/prisma.service';
+import { PrismaService } from '../../database/prisma/prisma.service';
 import { isEmpty, isEqual, pickBy } from 'lodash';
 import { Flight } from './interfaces/cgna.interface';
 import { Route } from '@prisma/client';

--- a/backend/src/modules/role/controllers/role.controller.ts
+++ b/backend/src/modules/role/controllers/role.controller.ts
@@ -1,11 +1,24 @@
-import { Controller } from '@nestjs/common';
-import { RoleRepository } from '../repositories/role.repository';
+import { Controller, Post, Delete, Param, Body } from '@nestjs/common';
+import { RoleService } from '../services/role.service';
 
 @Controller('role')
 export class RoleController {
-  constructor(private roleRepository: RoleRepository) {}
+  constructor(private roleService: RoleService) {}
 
   getUserRole(id: number) {
-    return this.roleRepository.getRolesByUserId(id);
+    return this.roleService.getUserRolesByUserId({ userId: id });
+  }
+
+  @Post('assign')
+  assignRoleToUser(@Body() body: { userId: number; roleId: number }) {
+    return this.roleService.assignRoleToUser(body.userId, body.roleId);
+  }
+
+  @Delete(':userId/role/:roleId')
+  removeRoleFromUser(
+    @Param('userId') userId: number,
+    @Param('roleId') roleId: number,
+  ) {
+    return this.roleService.removeRoleFromUser(userId, roleId);
   }
 }

--- a/backend/src/modules/role/repositories/role.repository.ts
+++ b/backend/src/modules/role/repositories/role.repository.ts
@@ -7,7 +7,35 @@ export class RoleRepository {
 
   async getRolesByUserId(id: number) {
     return this.prisma.role.findMany({
-      where: { UserRole: { some: { userId: id } } },
+      where: { users: { some: { id } } },
+    });
+  }
+
+  async assignRoleToUser(userId: number, roleId: number) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        roles: {
+          connect: { id: roleId },
+        },
+      },
+      include: {
+        roles: true,
+      },
+    });
+  }
+
+  async removeRoleFromUser(userId: number, roleId: number) {
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        roles: {
+          disconnect: { id: roleId },
+        },
+      },
+      include: {
+        roles: true,
+      },
     });
   }
 }

--- a/backend/src/modules/role/services/role.service.spec.ts
+++ b/backend/src/modules/role/services/role.service.spec.ts
@@ -1,0 +1,183 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { RoleService } from './role.service';
+import { RoleRepository } from '../repositories/role.repository';
+
+describe('RoleService', () => {
+  let service: RoleService;
+  let repository: RoleRepository;
+
+  const mockRoleRepository = {
+    getRolesByUserId: jest.fn(),
+    assignRoleToUser: jest.fn(),
+    removeRoleFromUser: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RoleService,
+        {
+          provide: RoleRepository,
+          useValue: mockRoleRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<RoleService>(RoleService);
+    repository = module.get<RoleRepository>(RoleRepository);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getUserRolesByUserId', () => {
+    const userId = 1;
+    const mockRoles = [
+      { id: 1, name: 'Admin' },
+      { id: 2, name: 'Pilot' },
+    ];
+
+    it('should return user roles', async () => {
+      // Arrange
+      mockRoleRepository.getRolesByUserId.mockResolvedValue(mockRoles);
+
+      // Act
+      const result = await service.getUserRolesByUserId({ userId });
+
+      // Assert
+      expect(mockRoleRepository.getRolesByUserId).toHaveBeenCalledWith(userId);
+      expect(result).toEqual(mockRoles);
+    });
+
+    it('should return empty array when user has no roles', async () => {
+      // Arrange
+      mockRoleRepository.getRolesByUserId.mockResolvedValue([]);
+
+      // Act
+      const result = await service.getUserRolesByUserId({ userId });
+
+      // Assert
+      expect(mockRoleRepository.getRolesByUserId).toHaveBeenCalledWith(userId);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('assignRoleToUser', () => {
+    const userId = 1;
+    const roleId = 2;
+    const mockUserWithRoles = {
+      id: userId,
+      name: 'João Silva',
+      email: 'joao@email.com',
+      username: 'joao123',
+      plan: 'FREE',
+      baseId: 1,
+      base: {
+        id: 1,
+        name: 'Base Test',
+        city: 'São Paulo',
+        state: 'SP',
+      },
+      roles: [
+        { id: 2, name: 'Pilot' },
+      ],
+      createdAt: new Date(),
+      updateAt: new Date(),
+    };
+
+    it('should assign role to user successfully', async () => {
+      // Arrange
+      mockRoleRepository.assignRoleToUser.mockResolvedValue(mockUserWithRoles);
+
+      // Act
+      const result = await service.assignRoleToUser(userId, roleId);
+
+      // Assert
+      expect(mockRoleRepository.assignRoleToUser).toHaveBeenCalledWith(userId, roleId);
+      expect(result).toEqual(mockUserWithRoles);
+    });
+
+    it('should return user with updated roles', async () => {
+      // Arrange
+      mockRoleRepository.assignRoleToUser.mockResolvedValue(mockUserWithRoles);
+
+      // Act
+      const result = await service.assignRoleToUser(userId, roleId);
+
+      // Assert
+      expect(result.roles).toBeDefined();
+      expect(result.roles).toHaveLength(1);
+      expect(result.roles[0]).toEqual({
+        id: 2,
+        name: 'Pilot',
+      });
+    });
+
+    it('should handle repository errors', async () => {
+      // Arrange
+      const error = new Error('Database error');
+      mockRoleRepository.assignRoleToUser.mockRejectedValue(error);
+
+      // Act & Assert
+      await expect(service.assignRoleToUser(userId, roleId)).rejects.toThrow('Database error');
+      expect(mockRoleRepository.assignRoleToUser).toHaveBeenCalledWith(userId, roleId);
+    });
+  });
+
+  describe('removeRoleFromUser', () => {
+    const userId = 1;
+    const roleId = 2;
+    const mockUserWithoutRole = {
+      id: userId,
+      name: 'João Silva',
+      email: 'joao@email.com',
+      username: 'joao123',
+      plan: 'FREE',
+      baseId: 1,
+      base: {
+        id: 1,
+        name: 'Base Test',
+        city: 'São Paulo',
+        state: 'SP',
+      },
+      roles: [], // Role removed
+      createdAt: new Date(),
+      updateAt: new Date(),
+    };
+
+    it('should remove role from user successfully', async () => {
+      // Arrange
+      mockRoleRepository.removeRoleFromUser.mockResolvedValue(mockUserWithoutRole);
+
+      // Act
+      const result = await service.removeRoleFromUser(userId, roleId);
+
+      // Assert
+      expect(mockRoleRepository.removeRoleFromUser).toHaveBeenCalledWith(userId, roleId);
+      expect(result).toEqual(mockUserWithoutRole);
+    });
+
+    it('should return user with updated roles (role removed)', async () => {
+      // Arrange
+      mockRoleRepository.removeRoleFromUser.mockResolvedValue(mockUserWithoutRole);
+
+      // Act
+      const result = await service.removeRoleFromUser(userId, roleId);
+
+      // Assert
+      expect(result.roles).toBeDefined();
+      expect(result.roles).toHaveLength(0);
+    });
+
+    it('should handle repository errors', async () => {
+      // Arrange
+      const error = new Error('Database error');
+      mockRoleRepository.removeRoleFromUser.mockRejectedValue(error);
+
+      // Act & Assert
+      await expect(service.removeRoleFromUser(userId, roleId)).rejects.toThrow('Database error');
+      expect(mockRoleRepository.removeRoleFromUser).toHaveBeenCalledWith(userId, roleId);
+    });
+  });
+}); 

--- a/backend/src/modules/role/services/role.service.ts
+++ b/backend/src/modules/role/services/role.service.ts
@@ -8,4 +8,12 @@ export class RoleService {
   async getUserRolesByUserId({ userId }: { userId: number }) {
     return this.roleRepository.getRolesByUserId(userId);
   }
+
+  async assignRoleToUser(userId: number, roleId: number) {
+    return this.roleRepository.assignRoleToUser(userId, roleId);
+  }
+
+  async removeRoleFromUser(userId: number, roleId: number) {
+    return this.roleRepository.removeRoleFromUser(userId, roleId);
+  }
 }

--- a/backend/src/modules/user/repositories/user.repository.spec.ts
+++ b/backend/src/modules/user/repositories/user.repository.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserRepository } from './user.repository';
+import { PrismaService } from '../../../database/prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+
+describe('UserRepository', () => {
+  let repository: UserRepository;
+  let prismaService: PrismaService;
+
+  const mockPrismaService = {
+    user: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+      update: jest.fn(),
+    },
+    role: {
+      findFirst: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserRepository,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    repository = module.get<UserRepository>(UserRepository);
+    prismaService = module.get<PrismaService>(PrismaService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createUser', () => {
+    const mockUserData: Prisma.UserCreateInput = {
+      name: 'João Silva',
+      email: 'joao@email.com',
+      username: 'joao123',
+      password: 'hashedPassword',
+      plan: 'FREE',
+      base: {
+        connect: { id: 1 },
+      },
+    };
+
+    const mockPilotRole = {
+      id: 2,
+      name: 'Pilot',
+    };
+
+    const mockCreatedUser = {
+      id: 1,
+      name: 'João Silva',
+      email: 'joao@email.com',
+      username: 'joao123',
+      password: 'hashedPassword',
+      plan: 'FREE',
+      baseId: 1,
+      base: {
+        id: 1,
+        name: 'Base Test',
+        city: 'São Paulo',
+        state: 'SP',
+      },
+      roles: [
+        {
+          id: 2,
+          name: 'Pilot',
+        },
+      ],
+      createdAt: new Date(),
+      updateAt: new Date(),
+    };
+
+    it('should create a user and automatically assign Pilot role', async () => {
+      // Arrange
+      mockPrismaService.role.findFirst.mockResolvedValue(mockPilotRole);
+      mockPrismaService.user.create.mockResolvedValue(mockCreatedUser);
+
+      // Act
+      const result = await repository.createUser(mockUserData);
+
+      // Assert
+      expect(mockPrismaService.role.findFirst).toHaveBeenCalledWith({
+        where: { name: 'Pilot' },
+      });
+      expect(mockPrismaService.user.create).toHaveBeenCalledWith({
+        data: {
+          ...mockUserData,
+          roles: {
+            connect: { id: mockPilotRole.id },
+          },
+        },
+        select: {
+          email: true,
+          id: true,
+          name: true,
+          username: true,
+          password: true,
+          plan: true,
+          baseId: true,
+          base: {
+            select: {
+              id: true,
+              name: true,
+              city: true,
+              state: true,
+            },
+          },
+          roles: {
+            select: {
+              id: true,
+              name: true,
+            },
+          },
+          createdAt: true,
+          updateAt: true,
+        },
+      });
+      expect(result).toEqual(mockCreatedUser);
+    });
+
+    it('should throw error when Pilot role is not found', async () => {
+      // Arrange
+      mockPrismaService.role.findFirst.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(repository.createUser(mockUserData)).rejects.toThrow(
+        'Pilot role not found',
+      );
+      expect(mockPrismaService.role.findFirst).toHaveBeenCalledWith({
+        where: { name: 'Pilot' },
+      });
+      expect(mockPrismaService.user.create).not.toHaveBeenCalled();
+    });
+
+    it('should include roles in the response', async () => {
+      // Arrange
+      mockPrismaService.role.findFirst.mockResolvedValue(mockPilotRole);
+      mockPrismaService.user.create.mockResolvedValue(mockCreatedUser);
+
+      // Act
+      const result = await repository.createUser(mockUserData);
+
+      // Assert
+      expect(result.roles).toBeDefined();
+      expect(result.roles).toHaveLength(1);
+      expect(result.roles[0]).toEqual({
+        id: 2,
+        name: 'Pilot',
+      });
+    });
+  });
+}); 

--- a/backend/src/modules/user/repositories/user.repository.ts
+++ b/backend/src/modules/user/repositories/user.repository.ts
@@ -1,14 +1,28 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
-import { PrismaService } from 'src/database/prisma/prisma.service';
+import { PrismaService } from '../../../database/prisma/prisma.service';
 
 @Injectable()
 export class UserRepository {
   constructor(private prisma: PrismaService) {}
 
-  createUser(data: Prisma.UserCreateArgs['data']) {
+  async createUser(data: Prisma.UserCreateArgs['data']) {
+    // Primeiro, vamos encontrar a role "Pilot"
+    const pilotRole = await this.prisma.role.findFirst({
+      where: { name: 'Pilot' },
+    });
+
+    if (!pilotRole) {
+      throw new Error('Pilot role not found');
+    }
+
     return this.prisma.user.create({
-      data,
+      data: {
+        ...data,
+        roles: {
+          connect: { id: pilotRole.id },
+        },
+      },
       select: {
         email: true,
         id: true,
@@ -23,6 +37,12 @@ export class UserRepository {
             name: true,
             city: true,
             state: true,
+          },
+        },
+        roles: {
+          select: {
+            id: true,
+            name: true,
           },
         },
         createdAt: true,

--- a/backend/src/modules/user/services/user.service.spec.ts
+++ b/backend/src/modules/user/services/user.service.spec.ts
@@ -1,0 +1,197 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+import { UserRepository } from '../repositories/user.repository';
+import { ConfigService } from '@nestjs/config';
+import { TypedEventEmitter } from '../../../common/modules/event-emitter/controllers/event-emitter.controller';
+import { Prisma } from '@prisma/client';
+import { ConflictException, InternalServerErrorException } from '@nestjs/common';
+import { UserEvent } from '../enums/user-event.enum';
+
+describe('UserService', () => {
+  let service: UserService;
+  let userRepository: UserRepository;
+  let configService: ConfigService;
+  let eventEmitter: TypedEventEmitter;
+
+  const mockUserRepository = {
+    createUser: jest.fn(),
+    findOne: jest.fn(),
+    findMany: jest.fn(),
+    findByUsernameOrEmail: jest.fn(),
+    login: jest.fn(),
+    updateUserPlan: jest.fn(),
+    updateUserBase: jest.fn(),
+  };
+
+  const mockConfigService = {
+    get: jest.fn(),
+  };
+
+  const mockEventEmitter = {
+    emit: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        UserService,
+        {
+          provide: UserRepository,
+          useValue: mockUserRepository,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+        {
+          provide: TypedEventEmitter,
+          useValue: mockEventEmitter,
+        },
+      ],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+    userRepository = module.get<UserRepository>(UserRepository);
+    configService = module.get<ConfigService>(ConfigService);
+    eventEmitter = module.get<TypedEventEmitter>(TypedEventEmitter);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createUser', () => {
+    const mockUserData: Prisma.UserCreateInput = {
+      name: 'João Silva',
+      email: 'joao@email.com',
+      username: 'joao123',
+      password: 'senha123',
+      plan: 'FREE',
+      base: {
+        connect: { id: 1 },
+      },
+    };
+
+    const mockCreatedUser = {
+      id: 1,
+      name: 'João Silva',
+      email: 'joao@email.com',
+      username: 'joao123',
+      password: 'hashedPassword',
+      plan: 'FREE',
+      baseId: 1,
+      base: {
+        id: 1,
+        name: 'Base Test',
+        city: 'São Paulo',
+        state: 'SP',
+      },
+      roles: [
+        {
+          id: 2,
+          name: 'Pilot',
+        },
+      ],
+      createdAt: new Date(),
+      updateAt: new Date(),
+    };
+
+    beforeEach(() => {
+      mockConfigService.get.mockReturnValue('10'); // BCRYPT_ROUNDS
+    });
+
+    it('should create a user with hashed password and Pilot role', async () => {
+      // Arrange
+      mockUserRepository.createUser.mockResolvedValue(mockCreatedUser);
+
+      // Act
+      const result = await service.createUser(mockUserData);
+
+      // Assert
+      expect(mockConfigService.get).toHaveBeenCalledWith('BCRYPT_ROUNDS');
+      expect(mockUserRepository.createUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...mockUserData,
+          password: expect.any(String), // Hashed password
+        }),
+      );
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith(UserEvent.CREATED, {
+        user: expect.objectContaining({
+          id: mockCreatedUser.id,
+          name: mockCreatedUser.name,
+          email: mockCreatedUser.email,
+          username: mockCreatedUser.username,
+          plan: mockCreatedUser.plan,
+          baseId: mockCreatedUser.baseId,
+          base: mockCreatedUser.base,
+          roles: mockCreatedUser.roles,
+          createdAt: mockCreatedUser.createdAt,
+          updateAt: mockCreatedUser.updateAt,
+        }),
+      });
+      expect(result).toEqual({
+        ...mockCreatedUser,
+        password: mockCreatedUser.password,
+      });
+    });
+
+    it('should include Pilot role in the created user', async () => {
+      // Arrange
+      mockUserRepository.createUser.mockResolvedValue(mockCreatedUser);
+
+      // Act
+      const result = await service.createUser(mockUserData);
+
+      // Assert
+      expect(result.roles).toBeDefined();
+      expect(result.roles).toHaveLength(1);
+      expect(result.roles[0]).toEqual({
+        id: 2,
+        name: 'Pilot',
+      });
+    });
+
+    it('should throw ConflictException when user already exists', async () => {
+      // Arrange
+      const prismaError = new Prisma.PrismaClientKnownRequestError('', {
+        code: 'P2002',
+        clientVersion: '1.0.0',
+        meta: { target: ['email'] },
+      });
+      mockUserRepository.createUser.mockRejectedValue(prismaError);
+
+      // Act & Assert
+      await expect(service.createUser(mockUserData)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('should throw InternalServerErrorException for unexpected errors', async () => {
+      // Arrange
+      const unexpectedError = new Error('Database connection failed');
+      mockUserRepository.createUser.mockRejectedValue(unexpectedError);
+
+      // Act & Assert
+      await expect(service.createUser(mockUserData)).rejects.toThrow(
+        InternalServerErrorException,
+      );
+      expect(mockEventEmitter.emit).not.toHaveBeenCalled();
+    });
+
+    it('should hash password before creating user', async () => {
+      // Arrange
+      mockUserRepository.createUser.mockResolvedValue(mockCreatedUser);
+
+      // Act
+      await service.createUser(mockUserData);
+
+      // Assert
+      expect(mockUserRepository.createUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          password: expect.not.stringMatching('senha123'), // Should be hashed
+        }),
+      );
+    });
+  });
+}); 

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,171 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { PrismaService } from '../src/database/prisma/prisma.service';
+
+describe('AuthController (e2e)', () => {
+  let app: INestApplication;
+  let prismaService: PrismaService;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    prismaService = moduleFixture.get<PrismaService>(PrismaService);
+  });
+
+  afterEach(async () => {
+    // Clean up test data
+    await prismaService.user.deleteMany({
+      where: {
+        email: {
+          in: [
+            'test@example.com',
+            'test2@example.com',
+            'different@example.com',
+          ],
+        },
+      },
+    });
+    await prismaService.user.deleteMany({
+      where: {
+        username: {
+          in: ['joao123', 'joao456'],
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('/auth/register (POST)', () => {
+    const getRegisterData = (suffix: string) => ({
+      firstName: 'João',
+      lastName: 'Silva',
+      email: `test${suffix}@example.com`,
+      username: `joao${suffix}`,
+      password: 'senha123456',
+      baseId: 1,
+    });
+
+    it('should create a user and automatically assign Pilot role', async () => {
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send(getRegisterData('1'))
+        .expect(201);
+
+      // Assert
+      expect(response.body).toHaveProperty('authToken');
+      expect(response.body).toHaveProperty('user');
+      expect(response.body.user).toHaveProperty('id');
+      expect(response.body.user).toHaveProperty('name', 'João Silva');
+      expect(response.body.user).toHaveProperty('email', 'test1@example.com');
+      expect(response.body.user).toHaveProperty('username', 'joao1');
+      expect(response.body.user).toHaveProperty('plan', 'FREE');
+      expect(response.body.user).toHaveProperty('baseId', 1);
+
+      // Verify that the user has the Pilot role in the database
+      const userWithRoles = await prismaService.user.findUnique({
+        where: { id: response.body.user.id },
+        include: {
+          roles: true,
+        },
+      });
+
+      expect(userWithRoles).toBeDefined();
+      expect(userWithRoles.roles).toHaveLength(1);
+      expect(userWithRoles.roles[0].name).toBe('Pilot');
+    });
+
+    it('should return user with roles included in response', async () => {
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send(getRegisterData('2'))
+        .expect(201);
+
+      // Assert
+      expect(response.body.user).toHaveProperty('roles');
+      expect(response.body.user.roles).toBeInstanceOf(Array);
+      expect(response.body.user.roles).toHaveLength(1);
+      expect(response.body.user.roles[0]).toHaveProperty('id');
+      expect(response.body.user.roles[0]).toHaveProperty('name', 'Pilot');
+    });
+
+    it('should hash the password before storing', async () => {
+      // Act
+      const response = await request(app.getHttpServer())
+        .post('/auth/register')
+        .send(getRegisterData('3'))
+        .expect(201);
+
+      // Assert
+      const userInDb = await prismaService.user.findUnique({
+        where: { id: response.body.user.id },
+        select: { password: true },
+      });
+
+      expect(userInDb.password).not.toBe('senha123456');
+      expect(userInDb.password).toMatch(
+        /^\$2[aby]\$\d{1,2}\$[./A-Za-z0-9]{53}$/,
+      ); // bcrypt hash pattern
+    });
+
+    it('should fail when Pilot role does not exist', async () => {
+      // Arrange - Delete Pilot role to simulate missing role
+      await prismaService.role.deleteMany({
+        where: { name: 'Pilot' },
+      });
+
+      // Act & Assert
+      await request(app.getHttpServer())
+        .post('/auth/register')
+        .send(getRegisterData('4'))
+        .expect(500);
+
+      // Restore Pilot role for other tests
+      await prismaService.role.create({
+        data: { name: 'Pilot' },
+      });
+    });
+
+    it('should fail when user with same email already exists', async () => {
+      // Arrange - Create first user
+      await request(app.getHttpServer())
+        .post('/auth/register')
+        .send(getRegisterData('5'))
+        .expect(201);
+
+      // Act & Assert - Try to create second user with same email
+      await request(app.getHttpServer())
+        .post('/auth/register')
+        .send(getRegisterData('5'))
+        .expect(409);
+    });
+
+    it('should fail when user with same username already exists', async () => {
+      // Arrange - Create first user
+      await request(app.getHttpServer())
+        .post('/auth/register')
+        .send(getRegisterData('6'))
+        .expect(201);
+
+      // Act & Assert - Try to create second user with same username but different email
+      await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          ...getRegisterData('6'),
+          email: 'different@example.com',
+        })
+        .expect(409);
+    });
+  });
+});

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -5,5 +5,8 @@
   "testRegex": ".e2e-spec.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1"
   }
 }


### PR DESCRIPTION
- Add automatic Pilot role assignment when user registers
- Remove duplicate UserRole table, use Prisma's automatic _userRoles table
- Update UserRepository to automatically connect new users with Pilot role
- Add comprehensive unit tests for UserRepository, UserService, and RoleService
- Add e2e tests for registration endpoint with role assignment
- Fix import paths for PrismaService across the codebase
- Update RoleController with endpoints for role management
- Add migration to remove UserRole table
- Update Jest configuration for proper path resolution