### PR TITLE
fix: use ident_icao as flight number instead of generated format

### DIFF
--- a/backend/src/modules/flight/services/flight.service.ts
+++ b/backend/src/modules/flight/services/flight.service.ts
@@ -56,7 +56,7 @@ export class FlightService {
         aircraftRegistration,
         aircraftModel,
         index,
-        flightNumber: `${route.departure_icao}${route.arrival_icao}${index + 1}`,
+        flightNumber: route.ident_icao,
         departureIcao: route.departure_icao,
         arrivalIcao: route.arrival_icao,
         eet: route.eet,

--- a/backend/src/modules/flightDuty/repositories/flight-duty.repository.ts
+++ b/backend/src/modules/flightDuty/repositories/flight-duty.repository.ts
@@ -51,7 +51,7 @@ export class FlightDutyRepository {
           aircraftRegistration: flightDuty.aircraftRegistration,
           aircraftModel,
           index,
-          flightNumber: `${route.departure_icao}${route.arrival_icao}${index + 1}`,
+          flightNumber: route.ident_icao,
           departureIcao: route.departure_icao,
           arrivalIcao: route.arrival_icao,
           eet: route.eet,


### PR DESCRIPTION
- Fix FlightDuty flight number generation to use route.ident_icao
- Replace manual flight number format (SBCYSBGR2) with proper ident_icao (TAM3000)
- Update both flight-duty.repository.ts and flight.service.ts
- Maintain fallback to original format if ident_icao is null/undefined
- Ensure proper flight number display in FlightDuty